### PR TITLE
fix countdown callbacks stability

### DIFF
--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 
 interface UseCountdownReturn {
   timeLeft: number
@@ -14,23 +14,23 @@ export function useCountdown(): UseCountdownReturn {
   const [isRunning, setIsRunning] = useState(false)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
-  const start = (duration: number) => {
+  const start = useCallback((duration: number) => {
     setTimeLeft(duration)
     setIsRunning(true)
-  }
+  }, [])
 
-  const stop = () => {
+  const stop = useCallback(() => {
     setIsRunning(false)
     if (intervalRef.current) {
       clearInterval(intervalRef.current)
       intervalRef.current = null
     }
-  }
+  }, [])
 
-  const reset = () => {
+  const reset = useCallback(() => {
     stop()
     setTimeLeft(0)
-  }
+  }, [stop])
 
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60)


### PR DESCRIPTION
## Summary
- wrap countdown start, stop, and reset in `useCallback`

## Testing
- `npm test` *(fails: Puzzle Generator > should ensure top move score is at least 50)*
- `npx -p puppeteer node` *(missing puppeteer module)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ba3626548320a375860351e9023c