### PR TITLE
fix: point quackle bridge to correct headers

### DIFF
--- a/service-quackle/Dockerfile
+++ b/service-quackle/Dockerfile
@@ -18,12 +18,14 @@ RUN git clone --depth=1 https://github.com/quackle/quackle.git /tmp/quackle && \
     cd /tmp/quackle && mkdir -p build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make -j"$(nproc)" && \
-    cp -r /tmp/quackle/lexica/* /usr/share/quackle/lexica/ 2>/dev/null || true
+    cp -r /tmp/quackle/lexica/* /usr/share/quackle/lexica/ 2>/dev/null || true && \
+    find /tmp/quackle -name game.h
 
 # Compila il bridge C++
 WORKDIR /srv
 COPY bridge/quackle_bridge.cpp /srv/bridge/quackle_bridge.cpp
 RUN g++ -O3 -std=c++17 \
+    -I/tmp/quackle/src/libquackle/include \
     -I/tmp/quackle/src/libquackle \
     /srv/bridge/quackle_bridge.cpp \
     /tmp/quackle/build/liblibquackle.a \

--- a/service-quackle/bridge/quackle_bridge.cpp
+++ b/service-quackle/bridge/quackle_bridge.cpp
@@ -8,12 +8,12 @@
 using json = nlohmann::json;
 
 // Header Quackle (adatta i path se serve)
-#include "game.h"
-#include "board.h"
-#include "rack.h"
-#include "move.h"
-#include "generator.h"
-#include "evaluator.h"
+#include "libquackle/game.h"
+#include "libquackle/board.h"
+#include "libquackle/rack.h"
+#include "libquackle/move.h"
+#include "libquackle/generator.h"
+#include "libquackle/evaluator.h"
 
 static std::string arg(int argc, char** argv, const std::string& k, const std::string& d) {
   for (int i=1;i<argc-1;++i) if (std::string(argv[i])==k) return std::string(argv[i+1]);


### PR DESCRIPTION
## Summary
- search Quackle build tree for headers during image build
- compile C++ bridge against Quackle's libquackle includes
- reference libquackle headers in bridge source

## Testing
- `python -m py_compile app/main.py`
- `docker build -t quackle-test .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b212861c248320bb6264eb5184580d