### PR TITLE
fix: build bridge with Quackle root headers

### DIFF
--- a/service-quackle/Dockerfile
+++ b/service-quackle/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /srv
 # Copia il bridge C++ e compila
 COPY bridge/quackle_bridge.cpp /srv/bridge/quackle_bridge.cpp
 RUN g++ -O3 -std=c++17 \
+    -I/tmp/quackle \
     -I/tmp/quackle/src/libquackle/include \
     -I/tmp/quackle/src/libquackle \
     -I/tmp/quackle/src \

--- a/service-quackle/bridge/quackle_bridge.cpp
+++ b/service-quackle/bridge/quackle_bridge.cpp
@@ -7,7 +7,7 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-// Header Quackle: includi i file principali senza il prefisso 'libquackle/'
+// Header Quackle: includi i file principali senza prefissi come 'libquackle/' o 'quackle/'
 #include "game.h"
 #include "board.h"
 #include "rack.h"


### PR DESCRIPTION
## Summary
- include Quackle repository root in g++ include paths so headers like game.h resolve
- clarify bridge comment about Quackle header includes

## Testing
- `python -m py_compile service-quackle/app/*.py`
- `docker build -t test-quackle service-quackle` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b225a992e88320ac7e73336cc63ccf