### PR TITLE
Require Quackle API URL and add CORS env example

### DIFF
--- a/service-quackle/.env.example
+++ b/service-quackle/.env.example
@@ -1,0 +1,2 @@
+# Comma-separated list of allowed origins for browser requests
+CORS_ORIGINS=https://preview--scarabeo-ace-44.lovable.app,https://scarabeo-ace-44.lovable.app

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
 // Centralized API configuration
-const raw = import.meta.env.VITE_QUACKLE_SERVICE_URL ?? '';
+const raw = import.meta.env.VITE_QUACKLE_SERVICE_URL;
+if (!raw) {
+  throw new Error('VITE_QUACKLE_SERVICE_URL is not defined');
+}
 export const API_BASE = raw.replace(/\/+$/, ''); // Remove trailing slash
 
 export const api = (path: string) =>


### PR DESCRIPTION
## Summary
- document CORS_ORIGINS for Quackle service
- ensure frontend fails fast when VITE_QUACKLE_SERVICE_URL is missing

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: expected 40 to be >= 50)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b35d0a8083209292fd431bacd296