### PR TITLE
feat: enhance quackle integration

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-VITE_QUACKLE_SERVICE_URL=https://scarabeo-ace-44-production.up.railway.app
+VITE_QUACKLE_SERVICE_URL="https://scarabeo-ace-44-production.up.railway.app"
 VITE_SUPABASE_PROJECT_ID="qjpvhhijujqblazdlfeg"
 VITE_SUPABASE_PUBLISHABLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFqcHZoaGlqdWpxYmxhemRsZmVnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MjU2MzYsImV4cCI6MjA2OTMwMTYzNn0.VkFsp0h4LSscjbwYXAvSOsRCg30ozOc3QBsK5-pzk2A"
 VITE_SUPABASE_URL="https://qjpvhhijujqblazdlfeg.supabase.co"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ cp .env.example .env
 # then edit .env and provide values for SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY
 ```
 
+## Quackle AI – Setup rapido
+
+### Variabili frontend
+`VITE_QUACKLE_SERVICE_URL=` (URL pubblico del servizio)
+
+### Test locali
+`QUACKLE_BASE=http://localhost:5000  npm run quackle:health`
+`QUACKLE_BASE=https://<railway-app>.up.railway.app  npm run quackle:test`
+
+### Diagnostica
+Visita /debug/quackle per testare /health e /best-move dal browser.
+
+#### NOTE (Operatore umano – Railway)
+- Imposta CORS_ORIGINS includendo tutti i domini del frontend (preview/prod).
+- Imposta la porta 5000 (il Dockerfile espone 5000).
+- Verifica /health pubblico dopo il deploy.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/c72bd105-8134-406f-8d24-e609c43ca3b0) and click on Share -> Publish.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "prebuild:prod": "node ./scripts/check-env.ts --prod",
+    "build:prod": "npm run prebuild:prod && vite build",
+    "quackle:health": "node -e \"(async()=>{const b=process.env.QUACKLE_BASE||'http://localhost:5000';const r=await fetch(b+'/health');console.log(await r.text())})()\"",
+    "quackle:test": "node ./scripts/test-quackle.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -1,0 +1,10 @@
+// Esci con codice ≠ 0 se manca la env in build prod
+const isProd = process.env.NODE_ENV === 'production' || process.argv.includes('--prod');
+const v = process.env.VITE_QUACKLE_SERVICE_URL || '';
+if (isProd && !v) {
+  console.error('[BUILD GUARD] VITE_QUACKLE_SERVICE_URL mancante per build production.');
+  process.exit(1);
+} else {
+  console.log('[BUILD GUARD] OK. VITE_QUACKLE_SERVICE_URL =', v || '(dev fallback)');
+  process.exit(0);
+}

--- a/scripts/test-quackle.mjs
+++ b/scripts/test-quackle.mjs
@@ -1,0 +1,19 @@
+import process from 'node:process';
+const base = process.env.QUACKLE_BASE || 'http://localhost:5000';
+
+const health = await fetch(`${base}/health`).then(r => r.text()).catch(e => String(e));
+console.log('[HEALTH]', health);
+
+const payload = {
+  board: {},
+  rack: [{ letter: 'A', points: 1 }, { letter: 'R', points: 1 }, { letter: 'E', points: 1 }],
+  difficulty: 'easy'
+};
+
+const r = await fetch(`${base}/best-move`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(payload)
+}).then(r => r.text()).catch(e => String(e));
+
+console.log('[BEST-MOVE]', r);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -17,12 +19,14 @@ import PuzzleGame from "./pages/PuzzleGame";
 import NotFound from "./pages/NotFound";
 import Daily from "./pages/Daily";
 import DailyChallengePage from "./pages/DailyChallenge";
+import QuackleDebug from "./pages/QuackleDebug";
 import { QuackleProvider } from "./contexts/QuackleContext";
 import { DictionaryProvider } from "./contexts/DictionaryContext";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { NotificationSystem } from "./components/NotificationSystem";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { checkHealth } from "@/config";
 
 const queryClient = new QueryClient();
 
@@ -52,6 +56,7 @@ const AppRoutes = () => {
           } />
           <Route path="/daily" element={<Daily />} />
           <Route path="/daily-challenge" element={<DailyChallengePage />} />
+            <Route path="/debug/quackle" element={<QuackleDebug />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
@@ -61,7 +66,17 @@ const AppRoutes = () => {
 }
 
 const AppContent = () => {
-  const { user } = useAuth()
+  const { user } = useAuth();
+  const [quackleDown, setQuackleDown] = useState(false);
+
+  useEffect(() => {
+    checkHealth().then((h) => {
+      if (!h.ok) {
+        setQuackleDown(true);
+        toast.error("Quackle AI non raggiungibile – controlla variabili e CORS");
+      }
+    });
+  }, []);
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-background">
@@ -80,6 +95,12 @@ const AppContent = () => {
               <ThemeToggle />
             </div>
           </header>
+            {quackleDown && (
+              <div className="bg-red-500 text-white text-center text-xs py-1">
+                Quackle AI non raggiungibile – controlla variabili e CORS
+              </div>
+            )}
+
           <main className="flex-1 overflow-auto">
             <AppRoutes />
           </main>

--- a/src/pages/QuackleDebug.tsx
+++ b/src/pages/QuackleDebug.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { quackleHealth, quackleBestMove, getQuackleBase } from '@/services/quackleClient';
+
+export default function QuackleDebug() {
+  const [health, setHealth] = useState<string>('');
+  const [result, setResult] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+
+  async function doHealth() {
+    setLoading(true);
+    try {
+      const h = await quackleHealth();
+      setHealth(JSON.stringify(h, null, 2));
+    } catch (e: any) {
+      setHealth(String(e?.message || e));
+    } finally { setLoading(false); }
+  }
+
+  async function doBestMove() {
+    setLoading(true);
+    try {
+      const payload = {
+        board: {}, // board vuota per smoke-test
+        rack: [{ letter: 'A', points: 1 }, { letter: 'R', points: 1 }, { letter: 'E', points: 1 }],
+        difficulty: 'easy'
+      };
+      const mv = await quackleBestMove(payload);
+      setResult(JSON.stringify(mv, null, 2));
+    } catch (e: any) {
+      setResult(String(e?.message || e));
+    } finally { setLoading(false); }
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Quackle Debug</h2>
+      <p><b>Base URL:</b> {getQuackleBase()}</p>
+      <button onClick={doHealth} disabled={loading}>Check /health</button>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>{health}</pre>
+      <hr />
+      <button onClick={doBestMove} disabled={loading}>POST /best-move (smoke)</button>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>{result}</pre>
+    </div>
+  );
+}

--- a/src/services/quackleClient.ts
+++ b/src/services/quackleClient.ts
@@ -1,35 +1,51 @@
-import type { PlacedTile } from '@/types/game'
-import { API_BASE, api } from '@/config'
+import type { PlacedTile } from '@/types/game';
+import { API_BASE, api } from '@/config';
 
 export interface QuackleMove {
-  tiles: PlacedTile[]
-  score: number
-  words: string[]
-  move_type: string
-  engine_fallback?: boolean
+  tiles: PlacedTile[];
+  score: number;
+  words: string[];
+  move_type: string;
+  engine_fallback?: boolean;
+  error?: string;
 }
 
-export async function quackleHealth(): Promise<boolean> {
+async function fetchWithTimeout(url: string, opts: RequestInit = {}, ms = 10000): Promise<Response> {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), ms);
   try {
-    const r = await fetch(api('/health'), { method: 'GET' })
-    if (!r.ok) return false
-    const j = await r.json()
-    return j?.status === 'ok'
-  } catch {
-    return false
+    const res = await fetch(url, { ...opts, signal: ctl.signal, mode: 'cors' as RequestMode });
+    clearTimeout(t);
+    return res;
+  } catch (e: any) {
+    clearTimeout(t);
+    // Heuristica CORS: TypeError: Failed to fetch/NetworkError
+    const msg = String(e?.message || e);
+    const maybeCORS = /Failed to fetch|NetworkError|TypeError/i.test(msg);
+    throw new Error(maybeCORS
+      ? `[CORS/Network] ${msg} — Verifica CORS_ORIGINS su backend e dominio frontend.`
+      : msg);
   }
 }
 
+export async function quackleHealth(): Promise<{ ok: boolean; status: number; body: string; base: string; }> {
+  const r = await fetchWithTimeout(api('/health'), { method: 'GET' }, 5000);
+  const body = await r.text().catch(() => '');
+  return { ok: r.ok, status: r.status, body, base: API_BASE };
+}
+
 export async function quackleBestMove(payload: any): Promise<QuackleMove> {
-  const r = await fetch(api('/best-move'), {
+  const r = await fetchWithTimeout(api('/best-move'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
-  })
-  if (!r.ok) throw new Error('best-move failed')
-  return await r.json()
+  }, 15000);
+
+  if (!r.ok) {
+    const txt = await r.text().catch(() => '');
+    throw new Error(`best-move failed: ${r.status} ${txt.slice(0,180)}`);
+  }
+  return await r.json();
 }
 
-export function getQuackleBase() {
-  return API_BASE
-}
+export function getQuackleBase() { return API_BASE; }


### PR DESCRIPTION
## Summary
- guard Quackle service envs and add health utility
- add Quackle client with timeout/CORS handling and debug page
- wire up startup health check and CLI helpers for Quackle

## Testing
- `npm test` *(fails: expected 40 to be greater than or equal to 50)*
- `npm run quackle:health`
- `npm run quackle:test`
- `env -u VITE_QUACKLE_SERVICE_URL NODE_OPTIONS=--loader=ts-node/esm npm run prebuild:prod`
- `VITE_QUACKLE_SERVICE_URL=http://example NODE_OPTIONS=--loader=ts-node/esm npm run prebuild:prod`
- `VITE_QUACKLE_SERVICE_URL=http://example NODE_OPTIONS=--loader=ts-node/esm npm run build:prod` *(fails: Failed to load PostCSS config)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c334e0b88320a8b966654bfef49a