### PR TITLE
Align Quackle board indices and validate tile placement

### DIFF
--- a/service-quackle/bridge/quackle_bridge.cpp
+++ b/service-quackle/bridge/quackle_bridge.cpp
@@ -71,14 +71,19 @@ int main(int argc, char** argv){
 
     // Place existing board tiles
     for (auto it = jboard.begin(); it != jboard.end(); ++it) {
-      int r=0,c=0; char comma;
-      std::istringstream sscoord(it.key()); sscoord>>r>>comma>>c;
-      char ch = std::toupper(it->value("letter","?")[0]);
+      int r = 0, c = 0; char comma;
+      std::istringstream sscoord(it.key()); sscoord >> r >> comma >> c;
+      // Convert from 1-based coordinates to Quackle's 0-based board
+      --r; --c;
+      char ch = std::toupper(it->value("letter", "?")[0]);
       if (it->value("isBlank", false)) ch = '?';
       Quackle::LetterString single;
       single.push_back(ch);
       Quackle::Move m = Quackle::Move::createPlaceMove(r, c, false, single);
       board.makeMove(m);
+      if (board.letter(r, c) != ch) {
+        throw std::runtime_error("failed to place existing tile");
+      }
     }
 
     // Generate best move
@@ -94,8 +99,8 @@ int main(int argc, char** argv){
     json tiles = json::array();
     const Quackle::LetterString ls = best.tiles();
     const std::string word(ls.begin(), ls.end());
-    int row = best.startrow;
-    int col = best.startcol;
+    int row = best.startrow - 1;
+    int col = best.startcol - 1;
     for (size_t i=0;i<word.size();++i){
       char l = word[i];
       if (l == '.') { if (best.horizontal) ++col; else ++row; continue; }


### PR DESCRIPTION
## Summary
- adjust existing-tile placement to convert JSON coordinates from 1-based to Quackle's 0-based grid and verify insertion
- normalize best move coordinates before returning tiles to the client

## Testing
- `g++ -O3 -std=c++17 -I/tmp/quackle -I/tmp/quackle/src/libquackle/include -I/tmp/quackle/src/libquackle -I/tmp/quackle/src /workspace/scarabeo-ace-44/service-quackle/bridge/quackle_bridge.cpp /tmp/quackle/build/liblibquackle.a -o /tmp/quackle_bridge -lboost_system -lboost_filesystem -lboost_regex -licuuc -licui18n -lpthread`
- `echo '{"board":{},"rack":[{"letter":"A"}]}' | /tmp/quackle_bridge` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68b81a69a0ac83208f8542d2bc121e13