### PR TITLE
Fix Quackle bot moves by passing difficulty

### DIFF
--- a/src/contexts/QuackleContext.tsx
+++ b/src/contexts/QuackleContext.tsx
@@ -7,7 +7,7 @@ import type { QuackleMove } from '@/services/quackleClient'
 interface QuackleContextType {
   difficulty: Difficulty | null
   setDifficulty: (difficulty: Difficulty) => void
-  makeMove: (gameState: GameState, playerRack: Tile[]) => Promise<QuackleMove | null>
+  makeMove: (gameState: GameState, playerRack: Tile[], difficulty: Difficulty | null) => Promise<QuackleMove | null>
   isThinking: boolean
 }
 

--- a/src/hooks/useGame.test.ts
+++ b/src/hooks/useGame.test.ts
@@ -7,11 +7,15 @@ vi.mock('@/hooks/use-toast', () => ({
 }))
 
 vi.mock('@/contexts/QuackleContext', () => ({
-  useQuackleContext: () => ({ difficulty: null, makeMove: vi.fn() })
+  useQuackleContext: () => ({ difficulty: null, setDifficulty: vi.fn(), makeMove: vi.fn(), isThinking: false })
 }))
 
 vi.mock('@/contexts/DictionaryContext', () => ({
   useDictionary: () => ({ isValidWord: () => true })
+}))
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()]
 }))
 
 import { useGame } from './useGame'
@@ -23,6 +27,7 @@ describe('useGame pass counter', () => {
     const { result } = renderHook(() => useGame())
 
     act(() => {
+      result.current.resetGame()
       result.current.passTurn()
       result.current.passTurn()
       result.current.passTurn()

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -472,7 +472,7 @@ export const useGame = () => {
       if (!currentPlayer.isBot) return prev
       
       // Start async Quackle move generation
-      quackleMakeMove(prev, currentPlayer.rack).then(bestMove => {
+      quackleMakeMove(prev, currentPlayer.rack, difficulty).then(bestMove => {
         if (!bestMove || bestMove.tiles.length === 0) {
           // Quackle passes if no valid moves
           setIsBotTurn(false)
@@ -681,7 +681,7 @@ export const useGame = () => {
       const makeBotMove = async () => {
         try {
           const botRack = gameState.players[gameState.currentPlayerIndex].rack
-          const move = await quackleMakeMove(gameState, botRack)
+          const move = await quackleMakeMove(gameState, botRack, activeDifficulty)
           
           console.log('[useGame] Bot move received:', move)
           console.log('[useGame] Move details - tiles:', move?.tiles?.length, 'move_type:', move?.move_type, 'engine_fallback:', move?.engine_fallback)

--- a/src/hooks/useQuackle.ts
+++ b/src/hooks/useQuackle.ts
@@ -9,7 +9,8 @@ export const useQuackle = () => {
 
   const makeMove = useCallback(async (
     gameState: GameState,
-    playerRack: Tile[]
+    playerRack: Tile[],
+    difficulty: Difficulty | null
   ): Promise<QuackleMove | null> => {
     if (!difficulty) return null
     
@@ -48,7 +49,7 @@ export const useQuackle = () => {
     } finally {
       setIsThinking(false)
     }
-  }, [difficulty])
+  }, [])
 
   return {
     difficulty,


### PR DESCRIPTION
## Summary
- Allow Quackle hook to accept difficulty as argument and decouple from internal state
- Pass active difficulty when requesting bot moves and update context/test mocks
- Adjust test to reset game before counting consecutive passes

## Testing
- `npm test -- --run` *(fails: rating-api/src/puzzle/__tests__/puzzle.test.ts > Puzzle Generator > should ensure top move score is at least 50)*
- `npm run lint` *(fails: React hook rule violations in pages/Game.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b846231e108320b3da0ed3aae1f2dd