### PR TITLE
Fix Quackle coordinate conversion for AI moves

### DIFF
--- a/src/hooks/useQuackle.ts
+++ b/src/hooks/useQuackle.ts
@@ -19,15 +19,20 @@ export const useQuackle = () => {
       // Add artificial thinking time for better UX
       const thinkingTime = getThinkingTime(difficulty)
       const boardObject: Record<string, any> = {}
-      gameState.board.forEach((tile, key) => {
-        boardObject[key] = {
+      gameState.board.forEach((tile) => {
+        const row = tile.row + 1
+        const col = tile.col + 1
+        const newKey = `${row},${col}`
+        boardObject[newKey] = {
           letter: tile.letter,
           points: tile.points,
-          row: tile.row,
-          col: tile.col,
+          row,
+          col,
           isBlank: tile.isBlank || false
         }
       })
+
+      console.log('[useQuackle] Sending board keys:', Object.keys(boardObject))
 
       const payload = {
         board: boardObject,


### PR DESCRIPTION
## Summary
- convert board coordinates to 1-based before sending to the Quackle service
- log board keys for debugging Quackle payload

## Testing
- `npm test` *(fails: Puzzle Generator > should ensure top move score is at least 50)*
- `npm run lint` *(fails: React Hooks must be called in the exact same order in every component render)*

------
https://chatgpt.com/codex/tasks/task_e_68b854f74fd883209bfd246172b86a22