### PR TITLE
Fix Quackle move mapping to avoid replacing anchor tiles

### DIFF
--- a/engine/quackle_wrapper/engine.cpp
+++ b/engine/quackle_wrapper/engine.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <unordered_map>
 #include <algorithm>
+#include <set>
 // #include "debug/memwrap.h"  // Disabled
 
 // Quackle headers (core only, no Qt)
@@ -674,6 +675,7 @@ int main(int argc, char** argv) {
         
         Quackle::Board &board = pos.underlyingBoardReference();
         board.prepareEmptyBoard();
+        std::set<std::pair<int,int>> originalBoardSquares;
 
         // Set rack - SEPARATE blanks from letters to avoid OOB in counts
         Quackle::Rack rack;
@@ -748,6 +750,7 @@ int main(int argc, char** argv) {
                 }
                 
                 char ch = std::toupper(static_cast<unsigned char>(cell[0]));
+                originalBoardSquares.insert({r, c});
                 // CRITICAL FIX: Use alphabet encode to convert ASCII to internal letters
                 std::string singleStr(1, ch);
                 Quackle::LetterString single = alphabet->encode(singleStr);
@@ -979,10 +982,34 @@ int main(int argc, char** argv) {
                 }
 
                 json pos_arr = json::array();
+                std::set<std::pair<int,int>> occupiedSquares = originalBoardSquares;
+                int nextRow = mv.startrow;
+                int nextCol = mv.startcol;
+                auto advanceCoordinate = [&](int &row, int &col) {
+                    if (mv.horizontal) {
+                        ++col;
+                    } else {
+                        ++row;
+                    }
+                };
                 for (size_t i = 0; i < tls.length(); ++i) {
-                    int rr = mv.startrow + (mv.horizontal ? 0 : static_cast<int>(i));
-                    int cc = mv.startcol + (mv.horizontal ? static_cast<int>(i) : 0);
-                    pos_arr.push_back(json::array({rr, cc}));
+                    bool foundSpot = false;
+                    for (int guard = 0; guard < 30; ++guard) {
+                        if (!occupiedSquares.count({nextRow, nextCol})) {
+                            foundSpot = true;
+                            break;
+                        }
+                        advanceCoordinate(nextRow, nextCol);
+                        if (nextRow < 0 || nextRow >= 15 || nextCol < 0 || nextCol >= 15) {
+                            break;
+                        }
+                    }
+                    if (!foundSpot || nextRow < 0 || nextRow >= 15 || nextCol < 0 || nextCol >= 15) {
+                        continue;
+                    }
+                    pos_arr.push_back(json::array({nextRow, nextCol}));
+                    occupiedSquares.insert({nextRow, nextCol});
+                    advanceCoordinate(nextRow, nextCol);
                 }
 
                 json jmv = {

--- a/service-quackle/bridge/quackle_bridge.cpp
+++ b/service-quackle/bridge/quackle_bridge.cpp
@@ -11,6 +11,7 @@
 #include <iomanip>
 #include <csignal>
 #include <sys/stat.h>
+#include <set>
 #include "nlohmann/json.hpp"
 using json = nlohmann::json;
 namespace fs = std::filesystem;
@@ -276,6 +277,7 @@ int main(int argc, char** argv){
 
     g_phase = "validate_input";
     const json jboard = req.value("board", json::object());
+    std::set<std::pair<int,int>> originalBoardSquares;
     const json jrack  = req.value("rack",  json::array());
     const std::string ruleset = req.value("ruleset", std::string("en"));
     const std::string diff = req.value("difficulty", std::string("medium"));
@@ -311,6 +313,7 @@ int main(int argc, char** argv){
         return 64;
       }
       boardCells++;
+      originalBoardSquares.insert({r, c});
       minRow = std::min(minRow, r);
       maxRow = std::max(maxRow, r);
       minCol = std::min(minCol, c);
@@ -932,6 +935,17 @@ int main(int argc, char** argv){
           debugLog("Move details: startRow=" + std::to_string(startRow) + ", startCol=" + std::to_string(startCol) + ", isHorizontal=" + std::string(isHorizontal ? "true" : "false"));
           
           // Create tile representations with proper coordinates
+          std::set<std::pair<int,int>> occupiedSquares = originalBoardSquares;
+          int nextRow = startRow;
+          int nextCol = startCol;
+          auto advanceCoordinate = [&](int &row, int &col) {
+            if (isHorizontal) {
+              ++col;
+            } else {
+              ++row;
+            }
+          };
+
           for (size_t i = 0; i < tilesStr.length(); ++i) {
             json tileJson;
             Quackle::Letter tileValue = tilesStr[i];
@@ -949,16 +963,26 @@ int main(int argc, char** argv){
             tileJson["letter"] = letterText;
             tileJson["isBlank"] = tileBlank;
             tileJson["points"] = tileBlank ? 0 : alphabetParams->score(baseLetter);
-            
-            // Calculate proper coordinates based on direction
-            if (isHorizontal) {
-              tileJson["row"] = startRow;
-              tileJson["col"] = startCol + static_cast<int>(i);
-            } else {
-              tileJson["row"] = startRow + static_cast<int>(i);
-              tileJson["col"] = startCol;
+
+            bool foundSpot = false;
+            for (int guard = 0; guard < 30; ++guard) {
+              if (!occupiedSquares.count({nextRow, nextCol})) {
+                foundSpot = true;
+                break;
+              }
+              advanceCoordinate(nextRow, nextCol);
+              if (nextRow < 0 || nextRow >= 15 || nextCol < 0 || nextCol >= 15) {
+                break;
+              }
             }
-            
+            if (!foundSpot || nextRow < 0 || nextRow >= 15 || nextCol < 0 || nextCol >= 15) {
+              continue;
+            }
+            tileJson["row"] = nextRow;
+            tileJson["col"] = nextCol;
+            occupiedSquares.insert({nextRow, nextCol});
+            advanceCoordinate(nextRow, nextCol);
+
             tiles.push_back(tileJson);
             primaryWord += letterText;
           }


### PR DESCRIPTION
## Summary
- track the squares already filled on the board before handing them to the Quackle engine
- skip those occupied coordinates when mapping generated moves back to tile placements in both the engine wrapper and bridge

## Testing
- python3 -m pytest service-quackle/tests/test_best_move_normalization.py *(fails: local environment lacks lexicon assets and board grid support for the patched tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b47419548327a5e3cd2c8b62f45a