### PR TITLE
Fix Quackle bot turn and tile placement issues

### DIFF
--- a/service-quackle/quackle_service/main.py
+++ b/service-quackle/quackle_service/main.py
@@ -305,6 +305,97 @@ def _letter_points_en(letter: str) -> int:
     if L in {"?","*"}: return 0
     return 1
 
+def _reconstruct_tiles_from_raw_move(raw_move: Dict[str, Any], words: Optional[Any] = None) -> List[Dict[str, Any]]:
+    """Rebuild placed tiles ensuring letters align with board coordinates and blanks."""
+    try:
+        positions_raw = raw_move.get("positions") or []
+    except AttributeError:
+        return []
+
+    pos_list: List[tuple[int, int]] = []
+    for pos in positions_raw:
+        if not isinstance(pos, (list, tuple)) or len(pos) < 2:
+            continue
+        try:
+            r = int(pos[0])
+            c = int(pos[1])
+        except (TypeError, ValueError):
+            continue
+        pos_list.append((r, c))
+
+    if not pos_list:
+        return []
+
+    try:
+        start_row = int(raw_move.get("row"))
+        start_col = int(raw_move.get("col"))
+    except (TypeError, ValueError):
+        return []
+
+    direction = str(raw_move.get("dir") or "H").upper()
+    raw_word = raw_move.get("word")
+    raw_word_str = str(raw_word) if isinstance(raw_word, str) or raw_word is not None else ""
+
+    first_word = ""
+    if isinstance(words, (list, tuple)) and words:
+        candidate = words[0]
+        if isinstance(candidate, str):
+            first_word = candidate
+        elif candidate is not None:
+            first_word = str(candidate)
+
+    full_word_str = first_word or raw_word_str.replace('.', '') or raw_word_str
+
+    tiles: List[Dict[str, Any]] = []
+    pos_idx = 0
+
+    for i, full_char in enumerate(full_word_str):
+        if pos_idx >= len(pos_list):
+            break
+
+        row = start_row + (0 if direction == 'H' else i)
+        col = start_col + (i if direction == 'H' else 0)
+        target = pos_list[pos_idx]
+
+        if target != (row, col):
+            continue
+
+        raw_char = raw_word_str[i] if i < len(raw_word_str) else ""
+        letter_char = full_char or raw_char
+
+        is_blank = False
+        if raw_char:
+            if raw_char in {'.'}:
+                # Existing board tile placeholder; use word character
+                letter_char = full_char
+            elif raw_char.islower():
+                is_blank = True
+                letter_char = full_char or raw_char.upper()
+            elif raw_char in {'?', '*'}:
+                is_blank = True
+                letter_char = full_char or raw_char.upper()
+            else:
+                letter_char = full_char or raw_char
+        else:
+            letter_char = full_char or letter_char
+
+        if not letter_char:
+            pos_idx += 1
+            continue
+
+        letter_up = letter_char.upper()
+        tiles.append({
+            "row": target[0],
+            "col": target[1],
+            "letter": letter_up,
+            "points": 0 if is_blank else _letter_points_en(letter_up),
+            "isBlank": is_blank
+        })
+
+        pos_idx += 1
+
+    return tiles
+
 def normalize_rack(raw: Any) -> str:
     """Accepts a string or list of characters/tiles and normalizes to 7-char uppercase string.
     Allowed characters: A-Z and blanks '?','*'. Spaces are ignored.
@@ -1121,8 +1212,15 @@ async def best_move(req: Request):
             return JSONResponse(body or {"engine_fallback": True, "error": err}, status_code=status)
 
         # Success path
+        tiles_out = result.get("tiles", [])
+        raw_move = result.get("raw_move") if isinstance(result, dict) else None
+        if isinstance(raw_move, dict):
+            rebuilt = _reconstruct_tiles_from_raw_move(raw_move, result.get("words"))
+            if rebuilt:
+                tiles_out = rebuilt
+
         return {
-            "tiles": result.get("tiles", []),
+            "tiles": tiles_out,
             "score": result.get("score", 0),
             "words": result.get("words", []),
             "move_type": result.get("move_type", "play" if result.get("tiles") else "pass"),

--- a/service-quackle/tests/test_best_move_normalization.py
+++ b/service-quackle/tests/test_best_move_normalization.py
@@ -1,5 +1,6 @@
 import re
 import json
+from typing import Any
 from fastapi.testclient import TestClient
 
 from quackle_service.main import app
@@ -130,3 +131,75 @@ def test_F_errors():
     })
     assert r3.status_code == 400
     assert r3.json().get("error") == "invalid_board_coordinate"
+
+
+def test_G_crossword_letters_from_raw_move(monkeypatch):
+    client = make_client()
+
+    def fake_bridge(_: Any):
+        return {
+            "tiles": [],
+            "score": 24,
+            "words": ["JOY"],
+            "move_type": "play",
+            "engine_fallback": False,
+            "raw_move": {
+                "word": "J.Y",
+                "row": 7,
+                "col": 7,
+                "dir": "V",
+                "positions": [[7, 7], [9, 7]]
+            }
+        }
+
+    import quackle_service.main as m
+    monkeypatch.setattr(m, "_call_bridge", fake_bridge)
+    monkeypatch.setattr(m, "ensure_lexicon_ready", lambda: (True, "", ""))
+
+    body = {
+        "rack": "AEIRSTZ",
+        "board": {"rows": 15, "cols": 15, "grid": ["."*15 for _ in range(15)]}
+    }
+
+    r = client.post("/best-move", json=body)
+    assert r.status_code == 200, r.text
+    tiles = r.json().get("tiles", [])
+    assert [t.get("letter") for t in tiles] == ["J", "Y"]
+
+
+def test_H_blank_tiles_preserve_letter(monkeypatch):
+    client = make_client()
+
+    def fake_bridge_blank(_: Any):
+        return {
+            "tiles": [],
+            "score": 16,
+            "words": ["AX"],
+            "move_type": "play",
+            "engine_fallback": False,
+            "raw_move": {
+                "word": "aX",
+                "row": 7,
+                "col": 7,
+                "dir": "H",
+                "positions": [[7, 7], [7, 8]]
+            }
+        }
+
+    import quackle_service.main as m
+    monkeypatch.setattr(m, "_call_bridge", fake_bridge_blank)
+    monkeypatch.setattr(m, "ensure_lexicon_ready", lambda: (True, "", ""))
+
+    body = {
+        "rack": "AEIRSTZ",
+        "board": {"rows": 15, "cols": 15, "grid": ["."*15 for _ in range(15)]}
+    }
+
+    r = client.post("/best-move", json=body)
+    assert r.status_code == 200, r.text
+    tiles = r.json().get("tiles", [])
+    assert len(tiles) == 2
+    assert tiles[0]["letter"] == "A"
+    assert tiles[0]["isBlank"] is True
+    assert tiles[1]["letter"] == "X"
+    assert tiles[1]["isBlank"] is False

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -38,6 +38,7 @@ export const useGame = () => {
   const [isSurrendered, setIsSurrendered] = useState(false)
   const [moveHistory, setMoveHistory] = useState<GameMove[]>([])
   const gameIdRef = useRef<string>(crypto.randomUUID())
+  const botMoveInFlightRef = useRef(false)
   
   // Initialize game state with proper bot mode detection
   const initializeGameState = useCallback((): GameState => {
@@ -640,12 +641,17 @@ export const useGame = () => {
       activeDifficulty: activeDifficulty
     })
 
-    if (gameState.gameStatus === 'playing' && 
-        currentPlayer?.isBot && 
-        !isBotTurn && 
+    if (gameState.gameStatus === 'playing' &&
+        currentPlayer?.isBot &&
+        !isBotTurn &&
         activeDifficulty) {
-      
+
+      if (botMoveInFlightRef.current) {
+        return
+      }
+
       console.log('[useGame] Triggering bot move')
+      botMoveInFlightRef.current = true
       setIsBotTurn(true)
       
       // Make bot move directly here to avoid circular dependencies
@@ -737,10 +743,11 @@ export const useGame = () => {
           toastOnce(toast, 'quackle-error', msg, { title: 'Quackle error', variant: 'destructive', cooldownMs: 5000 })
           // Do not call passTurn; surface error and keep turn
         } finally {
+          botMoveInFlightRef.current = false
           setIsBotTurn(false)
         }
       }
-      
+
       makeBotMove()
     }
   }, [gameState.currentPlayerIndex, gameState.gameStatus, isBotTurn, difficulty, urlDifficulty, quackleMakeMove, passTurn, exchangeTiles, toast])


### PR DESCRIPTION
## Summary
- guard the Quackle turn effect with an in-flight ref to prevent double moves when the bot starts
- normalize bridge responses so overlapping moves keep their letters and blanks map to the intended character
- add regression tests that exercise cross-letter and blank tile reconstruction when reading the bridge output

## Testing
- PYTHONPATH=service-quackle pytest service-quackle/tests/test_best_move_normalization.py::test_G_crossword_letters_from_raw_move service-quackle/tests/test_best_move_normalization.py::test_H_blank_tiles_preserve_letter
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3df6a199c8320a48bf2124352d476