### PR TITLE
Fix Quackle overlap tiles and normalize board inputs

### DIFF
--- a/service-quackle/quackle_service/main.py
+++ b/service-quackle/quackle_service/main.py
@@ -305,6 +305,118 @@ def _letter_points_en(letter: str) -> int:
     if L in {"?","*"}: return 0
     return 1
 
+def _reconstruct_tiles_from_raw_move(raw_move: Dict[str, Any], words: Optional[Any] = None) -> List[Dict[str, Any]]:
+    """Rebuild placed tiles ensuring letters align with board coordinates and blanks."""
+    try:
+        positions_raw = raw_move.get("positions") or []
+    except AttributeError:
+        return []
+
+    pos_list: List[tuple[int, int]] = []
+    for pos in positions_raw:
+        if not isinstance(pos, (list, tuple)) or len(pos) < 2:
+            continue
+        try:
+            r = int(pos[0])
+            c = int(pos[1])
+        except (TypeError, ValueError):
+            continue
+        pos_list.append((r, c))
+
+    if not pos_list:
+        return []
+
+    try:
+        start_row = int(raw_move.get("row"))
+        start_col = int(raw_move.get("col"))
+    except (TypeError, ValueError):
+        return []
+
+    direction = str(raw_move.get("dir") or "H").upper()
+    raw_word = raw_move.get("word")
+    if isinstance(raw_word, str):
+        raw_word_str = raw_word
+    elif raw_word is None:
+        raw_word_str = ""
+    else:
+        raw_word_str = str(raw_word)
+
+    first_word = ""
+    if isinstance(words, (list, tuple)) and words:
+        candidate = words[0]
+        if isinstance(candidate, str):
+            first_word = candidate
+        elif candidate is not None:
+            first_word = str(candidate)
+
+    raw_chars = list(raw_word_str)
+    word_chars = list(first_word)
+    same_length = len(word_chars) == len(raw_chars)
+    non_dot_length = len(word_chars) == sum(1 for ch in raw_chars if ch != '.') if word_chars else False
+
+    tiles: List[Dict[str, Any]] = []
+    pos_idx = 0
+    word_non_dot_idx = 0
+
+    for i, raw_char in enumerate(raw_chars):
+        if pos_idx >= len(pos_list):
+            break
+
+        row = start_row + (0 if direction == 'H' else i)
+        col = start_col + (i if direction == 'H' else 0)
+        target = pos_list[pos_idx]
+
+        if target != (row, col):
+            if non_dot_length and raw_char != '.':
+                word_non_dot_idx = min(word_non_dot_idx + 1, len(word_chars))
+            continue
+
+        if same_length and i < len(word_chars):
+            full_char = word_chars[i]
+        elif non_dot_length and raw_char != '.' and word_non_dot_idx < len(word_chars):
+            full_char = word_chars[word_non_dot_idx]
+        else:
+            full_char = raw_char
+
+        letter_char = full_char or raw_char
+
+        is_blank = False
+        if raw_char:
+            if raw_char in {'.'}:
+                # Existing board tile placeholder; use word character
+                letter_char = full_char
+            elif raw_char.islower():
+                is_blank = True
+                letter_char = full_char or raw_char.upper()
+            elif raw_char in {'?', '*'}:
+                is_blank = True
+                letter_char = full_char or raw_char.upper()
+            else:
+                letter_char = full_char or raw_char
+        else:
+            letter_char = full_char or letter_char
+
+        if not letter_char:
+            pos_idx += 1
+            if non_dot_length and raw_char != '.':
+                word_non_dot_idx = min(word_non_dot_idx + 1, len(word_chars))
+            continue
+
+        letter_up = letter_char.upper()
+        tiles.append({
+            "row": target[0],
+            "col": target[1],
+            "letter": letter_up,
+            "points": 0 if is_blank else _letter_points_en(letter_up),
+            "isBlank": is_blank
+        })
+
+        pos_idx += 1
+        if non_dot_length and raw_char != '.':
+            word_non_dot_idx = min(word_non_dot_idx + 1, len(word_chars))
+
+    return tiles
+
 def normalize_rack(raw: Any) -> str:
     """Accepts a string or list of characters/tiles and normalizes to 7-char uppercase string.
     Allowed characters: A-Z and blanks '?','*'. Spaces are ignored.
@@ -485,36 +597,29 @@ def _normalize_board_for_bridge(board_input: Any) -> Dict[str, Any]:
       - legacy grid: List[str] (15x15)
       - object: {"rows":15, "cols":15, "grid":[...15 strings...]}
         (may include extra metadata like center_x/center_y which are ignored)
-    Returns a sanitized object {"rows":15,"cols":15,"grid":[...]}.
+    Returns a sanitized object {"rows":15,"cols":15,"grid":[...]}. 
     Raises HTTPException(400) for invalid shapes.
     """
-    # Extract grid depending on type
-    if isinstance(board_input, list):
-        # Legacy form: list[str] (15 strings)
-        grid = board_input
-    elif isinstance(board_input, dict):
-        # Accept either an object with grid, or a 1-based coordinate map (possibly empty {})
-        if "grid" in board_input:
-            grid = board_input.get("grid")
-        elif _is_coord_map(board_input):
-            # Build a 15x15 grid from provided coordinates
-            rows = 15
-            cols = 15
-            squares = _squares_from_coord_map(board_input, rows, cols)
-            grid = [
-                ''.join(
-                    '.' if (v is None or v == '' or v == '.') else ('?' if v in ('?', '*') else str(v).upper()[:1])
-                    for v in row
-                )
-                for row in squares
-            ]
-        else:
-            raise HTTPException(status_code=400, detail="board.grid missing")
-    else:
-        raise HTTPException(status_code=400, detail="board invalid type")
+    try:
+        rows, cols, _, _, squares, _ = normalize_board(board_input)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=400, detail="malformed_board")
 
-    # Validate grid shape
-    if not (isinstance(grid, list) and len(grid) == 15 and all(isinstance(r, str) and len(r) == 15 for r in grid)):
+    grid = [
+        ''.join(
+            '.' if (cell is None or cell == '' or cell == '.')
+            else ('?' if str(cell).upper()[:1] in {'?', '*'} else str(cell).upper()[:1])
+            for cell in row
+        )
+        for row in squares
+    ]
+
+    if rows != 15 or cols != 15:
+        raise HTTPException(status_code=400, detail="board.grid must be 15 strings of length 15")
+
+    if any(len(r) != 15 for r in grid) or len(grid) != 15:
         raise HTTPException(status_code=400, detail="board.grid must be 15 strings of length 15")
 
     return {"rows": 15, "cols": 15, "grid": grid}
@@ -1121,8 +1226,15 @@ async def best_move(req: Request):
             return JSONResponse(body or {"engine_fallback": True, "error": err}, status_code=status)
 
         # Success path
+        tiles_out = result.get("tiles", [])
+        raw_move = result.get("raw_move") if isinstance(result, dict) else None
+        if isinstance(raw_move, dict):
+            rebuilt = _reconstruct_tiles_from_raw_move(raw_move, result.get("words"))
+            if rebuilt:
+                tiles_out = rebuilt
+
         return {
-            "tiles": result.get("tiles", []),
+            "tiles": tiles_out,
             "score": result.get("score", 0),
             "words": result.get("words", []),
             "move_type": result.get("move_type", "play" if result.get("tiles") else "pass"),

--- a/service-quackle/tests/test_best_move_normalization.py
+++ b/service-quackle/tests/test_best_move_normalization.py
@@ -1,5 +1,6 @@
 import re
 import json
+from typing import Any
 from fastapi.testclient import TestClient
 
 from quackle_service.main import app
@@ -27,12 +28,20 @@ def patch_bridge(monkeypatch, assert_fn=None):
         assert isinstance(payload.get("rack"), str)
         assert re.fullmatch(r"[A-Z\?\*]{7}", payload["rack"]) is not None
         assert isinstance(payload.get("board"), dict)
+        board_payload = payload.get("board")
+        if isinstance(board_payload, dict) and "grid" in board_payload:
+            board_payload = m._grid_to_coordmap(board_payload["grid"])
+        elif isinstance(board_payload, dict) and m._is_coord_map(board_payload):
+            board_payload = board_payload
+        else:
+            board_payload = {}
         # Optional custom assertions per-test
         if assert_fn:
-            assert_fn(payload)
+            assert_fn({**payload, "board": board_payload})
         return fake_play_response()
 
     monkeypatch.setattr(m, "_call_bridge", _fake_call_bridge)
+    monkeypatch.setattr(m, "ensure_lexicon_ready", lambda: (True, "", ""))
 
 
 def test_A_board_grid_empty(monkeypatch):
@@ -130,3 +139,109 @@ def test_F_errors():
     })
     assert r3.status_code == 400
     assert r3.json().get("error") == "invalid_board_coordinate"
+
+
+def test_G_crossword_letters_from_raw_move(monkeypatch):
+    client = make_client()
+
+    def fake_bridge(_: Any):
+        return {
+            "tiles": [],
+            "score": 24,
+            "words": ["JOY"],
+            "move_type": "play",
+            "engine_fallback": False,
+            "raw_move": {
+                "word": "J.Y",
+                "row": 7,
+                "col": 7,
+                "dir": "V",
+                "positions": [[7, 7], [9, 7]]
+            }
+        }
+
+    import quackle_service.main as m
+    monkeypatch.setattr(m, "_call_bridge", fake_bridge)
+    monkeypatch.setattr(m, "ensure_lexicon_ready", lambda: (True, "", ""))
+
+    body = {
+        "rack": "AEIRSTZ",
+        "board": {"rows": 15, "cols": 15, "grid": ["."*15 for _ in range(15)]}
+    }
+
+    r = client.post("/best-move", json=body)
+    assert r.status_code == 200, r.text
+    tiles = r.json().get("tiles", [])
+    assert [t.get("letter") for t in tiles] == ["J", "Y"]
+
+
+def test_H_blank_tiles_preserve_letter(monkeypatch):
+    client = make_client()
+
+    def fake_bridge_blank(_: Any):
+        return {
+            "tiles": [],
+            "score": 16,
+            "words": ["AX"],
+            "move_type": "play",
+            "engine_fallback": False,
+            "raw_move": {
+                "word": "aX",
+                "row": 7,
+                "col": 7,
+                "dir": "H",
+                "positions": [[7, 7], [7, 8]]
+            }
+        }
+
+    import quackle_service.main as m
+    monkeypatch.setattr(m, "_call_bridge", fake_bridge_blank)
+    monkeypatch.setattr(m, "ensure_lexicon_ready", lambda: (True, "", ""))
+
+    body = {
+        "rack": "AEIRSTZ",
+        "board": {"rows": 15, "cols": 15, "grid": ["."*15 for _ in range(15)]}
+    }
+
+    r = client.post("/best-move", json=body)
+    assert r.status_code == 200, r.text
+    tiles = r.json().get("tiles", [])
+    assert len(tiles) == 2
+    assert tiles[0]["letter"] == "A"
+    assert tiles[0]["isBlank"] is True
+    assert tiles[1]["letter"] == "X"
+    assert tiles[1]["isBlank"] is False
+
+
+def test_I_crossword_without_words_list(monkeypatch):
+    client = make_client()
+
+    def fake_bridge(_: Any):
+        return {
+            "tiles": [],
+            "score": 24,
+            "words": [],
+            "move_type": "play",
+            "engine_fallback": False,
+            "raw_move": {
+                "word": "J.Y",
+                "row": 7,
+                "col": 7,
+                "dir": "V",
+                "positions": [[7, 7], [9, 7]]
+            }
+        }
+
+    import quackle_service.main as m
+    monkeypatch.setattr(m, "_call_bridge", fake_bridge)
+    monkeypatch.setattr(m, "ensure_lexicon_ready", lambda: (True, "", ""))
+
+    body = {
+        "rack": "AEIRSTZ",
+        "board": {"rows": 15, "cols": 15, "grid": ["."*15 for _ in range(15)]}
+    }
+
+    r = client.post("/best-move", json=body)
+    assert r.status_code == 200, r.text
+    tiles = r.json().get("tiles", [])
+    assert [t.get("letter") for t in tiles] == ["J", "Y"]

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -38,6 +38,7 @@ export const useGame = () => {
   const [isSurrendered, setIsSurrendered] = useState(false)
   const [moveHistory, setMoveHistory] = useState<GameMove[]>([])
   const gameIdRef = useRef<string>(crypto.randomUUID())
+  const botMoveInFlightRef = useRef(false)
   
   // Initialize game state with proper bot mode detection
   const initializeGameState = useCallback((): GameState => {
@@ -640,12 +641,17 @@ export const useGame = () => {
       activeDifficulty: activeDifficulty
     })
 
-    if (gameState.gameStatus === 'playing' && 
-        currentPlayer?.isBot && 
-        !isBotTurn && 
+    if (gameState.gameStatus === 'playing' &&
+        currentPlayer?.isBot &&
+        !isBotTurn &&
         activeDifficulty) {
-      
+
+      if (botMoveInFlightRef.current) {
+        return
+      }
+
       console.log('[useGame] Triggering bot move')
+      botMoveInFlightRef.current = true
       setIsBotTurn(true)
       
       // Make bot move directly here to avoid circular dependencies
@@ -678,7 +684,7 @@ export const useGame = () => {
               move.tiles.forEach(tile => {
                 const key = `${tile.row},${tile.col}`
                 newBoard.set(key, {
-                  letter: tile.letter,
+                  letter: (tile.letter || '').toUpperCase(),
                   points: tile.points,
                   row: tile.row,
                   col: tile.col,
@@ -737,10 +743,11 @@ export const useGame = () => {
           toastOnce(toast, 'quackle-error', msg, { title: 'Quackle error', variant: 'destructive', cooldownMs: 5000 })
           // Do not call passTurn; surface error and keep turn
         } finally {
+          botMoveInFlightRef.current = false
           setIsBotTurn(false)
         }
       }
-      
+
       makeBotMove()
     }
   }, [gameState.currentPlayerIndex, gameState.gameStatus, isBotTurn, difficulty, urlDifficulty, quackleMakeMove, passTurn, exchangeTiles, toast])


### PR DESCRIPTION
## Summary
- keep Quackle raw-move reconstruction aligned with placeholder dots so crossover plays and blanks place the right uppercase letters
- reuse `normalize_board` inside the bridge adapter to accept legacy grids, placements, and squares while emitting a sanitized 15×15 grid
- uppercase bot tiles when applying moves on the frontend and extend regression tests for Quackle board normalization scenarios

## Testing
- PYTHONPATH=service-quackle pytest service-quackle/tests/test_best_move_normalization.py
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3df6a199c8320a48bf2124352d476